### PR TITLE
latexindent: add version 3.8

### DIFF
--- a/bucket/latexindent.json
+++ b/bucket/latexindent.json
@@ -1,0 +1,17 @@
+{
+    "homepage": "https://github.com/cmhughes/latexindent.pl",
+    "version": "3.8",
+    "description": "a pre-built windows executable to indent Latex files so as to beautify Latex code.",
+    "license": "GPL-3.0",
+    "extract_dir": "latexindent",
+    "bin":         "latexindent.exe",
+    "url": "http://mirrors.ctan.org/support/latexindent.zip",
+    "hash": "7c5dbcc697ec4bc29e2fe4499e5c30d1c63d318270403ee72caa2251cff027dd",
+    "checkver": {
+        "github": "https://github.com/cmhughes/latexindent.pl",
+        "regex": "tag/V([\\w-.]+)"
+    },
+    "autoupdate": {
+        "url": "http://mirrors.ctan.org/support/latexindent.zip"
+    }
+}


### PR DESCRIPTION
Latexindent is a Perl script to indent Latex files and make the code beautiful. It is distributed with many Latex distribution, e.g., MikTex (in Scoop Main bucket https://github.com/ScoopInstaller/Main/blob/master/bucket/latex.json). However, it requires the Perl environment and some extra dependencies. Many dependencies are not well maintained. It is difficult to build and run this script for many Latex users even though this script is easy to installed via MikTex. 

The official maintainer of latexindent release a window executable binary and keep this binary up to date. I create this pull request to add this binary into this bucket.